### PR TITLE
FEAT: gh-actions for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Exit if not on master branch
+        if: endsWith(github.ref, 'master') == false
+        run: exit 0
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org
+      - name: Build and npm publish
+        run: |
+          yarn
+          yarn build
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.LIFEOMIC_NPM_TOKEN}}
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "author": "Tony Ward <tony.ward@lifeomic.com>",
   "license": "MIT",
   "scripts": {
-    "prepublishOnly": "npm run build",
     "build": "npm run build:lined && npm run build:react",
     "build:lined": "rm -rf ./lined && cp -R src/lined lined/",
     "build:react": "svgr -d react src --svg-props viewBox='0 0 24 24'"


### PR DESCRIPTION
### Changes

- Wire up gh-actions for publishing public package

I decided to remove the pre-publish script, as we only publish with gh-actions and I added `yarn build` as a run step in the action itself.