### PR TITLE
FIX: Add viewBox to React output, add clean command, don't run build twice during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
         run: |
           yarn
           yarn generate:build-output
-          yarn build
           npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.LIFEOMIC_NPM_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "analyze": "size-limit --why",
     "build": "tsdx build",
+    "clean": "rm -rf src/lined && rm -rf dist/",
     "generate:build-output": "yarn generate:react-components && yarn generate:index-file",
     "generate:index-file": "echo \"export * from './lined'\" > src/index.tsx",
     "generate:react-components": "svgr --template svg-template.js src/raw/lined --out-dir src/lined --typescript",

--- a/svg-template.js
+++ b/svg-template.js
@@ -5,11 +5,16 @@
 
 function template(
   { template },
-  opts,
+  _,
   { imports, componentName, props, jsx, exports }
 ) {
   jsx.openingElement.attributes = [
     ...jsx.openingElement.attributes,
+    {
+      type: 'JSXAttribute',
+      name: { type: 'JSXIdentifier', name: 'viewBox' },
+      value: { type: 'StringLiteral', value: '0 0 24 24' },
+    },
     {
       type: 'JSXAttribute',
       name: { type: 'JSXIdentifier', name: 'data-icon' },


### PR DESCRIPTION
### Changes

- Don't run `build` twice during release
  - https://tsdx.io/#code-prepare-code-script `prepare` runs automatically, calling build
- Add `clean` command
- Add `viewBox` - without this, the SVGs would not appear correctly.  I somehow missed this initially

