### PR TITLE
feat: Add Enlarge icon

### DIFF
--- a/src/raw/lined/enlarge.svg
+++ b/src/raw/lined/enlarge.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+  <path d="M20.1 3.9L13.8 10.2" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M3.89999 20.1L10.2 13.8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M14.7 3.9H20.1V9.3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M9.29999 20.1001H3.89999V14.7001" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+</svg>


### PR DESCRIPTION
### Changes

- Add Enlarge icon

<img width="39" alt="Screen Shot 2021-03-12 at 3 52 10 PM" src="https://user-images.githubusercontent.com/8069555/110997111-eb187800-834a-11eb-9871-302df675e6b0.png">


Output is:

```jsx
import * as React from 'react';

const SvgEnlarge = (props: React.SVGProps<SVGSVGElement>) => (
  <svg
    width={24}
    height={24}
    stroke="currentColor"
    xmlns="http://www.w3.org/2000/svg"
    viewBox="0 0 24 24"
    data-icon="SvgEnlarge"
    {...props}
  >
    <path
      d="M20.1 3.9l-6.3 6.3M3.9 20.1l6.3-6.3M14.7 3.9h5.4v5.4M9.3 20.1H3.9v-5.4"
      strokeWidth={2}
      strokeLinecap="round"
      strokeLinejoin="round"
    />
  </svg>
);

export default SvgEnlarge;

```