### PR TITLE
feat: Auto-add aria-hidden to all generated React components

### DIFF
--- a/svg-template.js
+++ b/svg-template.js
@@ -1,6 +1,5 @@
 /**
- * Current use case is adding the `data-icon` attribute to each SVG when
- * exported as a React component.
+ * This template allows us to modify the generated React component template.
  */
 
 function template(
@@ -15,10 +14,19 @@ function template(
       name: { type: 'JSXIdentifier', name: 'viewBox' },
       value: { type: 'StringLiteral', value: '0 0 24 24' },
     },
+    // Currently documentation folks at LifeOmic use `data-icon` to identify
+    // which icon is being used so they can import it in their app
     {
       type: 'JSXAttribute',
       name: { type: 'JSXIdentifier', name: 'data-icon' },
       value: { type: 'StringLiteral', value: componentName.name },
+    },
+    // For our generated React components, we think this makes sense
+    // to do by default: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute
+    {
+      type: 'JSXAttribute',
+      name: { type: 'JSXIdentifier', name: 'aria-hidden' },
+      value: { type: 'StringLiteral', value: 'true' },
     },
   ];
   return template.ast`


### PR DESCRIPTION
### Changes

- Auto-add `aria-hidden="true"` to all generated React components
  - **NOTE:** raw SVGs are left as-is
  - Some additional reading material
    - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute
    - https://stackoverflow.com/questions/61048356/why-do-we-use-aria-hidden-with-icons
    - https://www.w3.org/WAI/GL/wiki/Using_aria-hidden%3Dtrue_on_an_icon_font_that_AT_should_ignore

I've been toying with this idea for a while now.  I think doing this by default is the right thing to do for us.  In ~95+% of cases so far with Chromicons in our apps, we use `aria-hidden` when rendering an icon on its own so that the icon does not get added to the accessibility tree / get picked up by screenreaders.  In Chroma, we do this as well, and we provide `aria-label` to describe the parent element instead (i.e., IconButton is a `<button` + descriptive `aria-label` with an icon inside that has `aria-hidden`).  

I don't think I've ran across a case yet where I _want_ the icon to be picked up by the AT.  The benefit of doing this is that it won't be another item to think about come review time (i.e, "please add `aria-hidden` to this icon" - https://github.com/lifeomic/chroma-react/pull/182).  The down side of doing this is that it removes some a11y chats from PR review and I suppose there could be some cases where we want the icon to be picked up (probably super rare?).

<img width="1658" alt="aria-hidden" src="https://user-images.githubusercontent.com/8069555/129245040-f4a3a1ba-5d80-4a0d-b9ed-2c56d7abd4eb.png">
