### PR TITLE
fix: Remove the package prepare script so we can release new versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "generate:react-components": "svgr --template svg-template.js src/raw/lined --out-dir src/build/react/lined --typescript",
     "generate:react-native-components": "svgr --template svg-rn-template.js src/raw/lined --out-dir src/build/native/lined --typescript --native",
     "lint": "tsdx lint",
-    "prepare": "tsdx build",
     "size": "size-limit",
     "start": "tsdx watch",
     "test": "tsdx test --passWithNoTests"
@@ -63,11 +62,11 @@
   },
   "size-limit": [
     {
-      "path": "dist/chromicons.cjs.production.min.js",
+      "path": "build/react/dist/chromicons.cjs.production.min.js",
       "limit": "15 KB"
     },
     {
-      "path": "dist/chromicons.esm.js",
+      "path": "build/react/dist/chromicons.esm.js",
       "limit": "15 KB"
     }
   ]


### PR DESCRIPTION
The previous build failed because the `prepare` script is run as part of the release and `tsdx build` doesn't work with our current setup of building each lib individually and providing the root file. Additionally, doing any build in the prepare step isn't needed since we do the build as part of the github release workflow. 

Also fixed the `size-limit` config to point at the new react components build destination.