### PR TITLE
fix: Include images in the png package deploy

### DIFF
--- a/prepare-packages.js
+++ b/prepare-packages.js
@@ -33,6 +33,7 @@ const transformPngsPackageJSON = package => {
   delete package.main;
   delete package.typings;
   delete package.module;
+  package.files.push('lined');
 
   return package;
 };


### PR DESCRIPTION
- Package.json for PNG module didn't include the actual images. This modifies the prepare script to include them in the bundle