### PR TITLE
feat: Add alternate sizing for chevrons, arrows, plus, minus, check and x

### DIFF
--- a/src/raw/lined/arrow-down-2.svg
+++ b/src/raw/lined/arrow-down-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M6.55554 13.0889L12 19M12 19L12 5M12 19L17.4444 13.0889" />
+</svg>

--- a/src/raw/lined/arrow-down-3.svg
+++ b/src/raw/lined/arrow-down-3.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M7.33331 12.9333L12 18M12 18L12 6M12 18L16.6666 12.9333"/>
+</svg>

--- a/src/raw/lined/arrow-left-2.svg
+++ b/src/raw/lined/arrow-left-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M10.9111 6.55554L5 12M5 12H19M5 12L10.9111 17.4444"/>
+</svg>

--- a/src/raw/lined/arrow-left-3.svg
+++ b/src/raw/lined/arrow-left-3.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M11.0667 7.33331L6 12M6 12H18M6 12L11.0667 16.6666"/>
+</svg>

--- a/src/raw/lined/arrow-right-2.svg
+++ b/src/raw/lined/arrow-right-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M13.0889 17.4445L19 12M19 12L5 12M19 12L13.0889 6.55557"/>
+</svg>

--- a/src/raw/lined/arrow-right-3.svg
+++ b/src/raw/lined/arrow-right-3.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M12.9333 16.6667L18 12M18 12L6 12M18 12L12.9333 7.33335"/>
+</svg>

--- a/src/raw/lined/arrow-up-2.svg
+++ b/src/raw/lined/arrow-up-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M17.4445 10.9111L12 5M12 5L12 19M12 5L6.55557 10.9111"/>
+</svg>

--- a/src/raw/lined/arrow-up-3.svg
+++ b/src/raw/lined/arrow-up-3.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M16.6667 11.0667L12 6M12 6L12 18M12 6L7.33335 11.0667"/>
+</svg>

--- a/src/raw/lined/check-2.svg
+++ b/src/raw/lined/check-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M5 14.1L9.2 17.9111L19 6.08887"/>
+</svg>

--- a/src/raw/lined/check-3.svg
+++ b/src/raw/lined/check-3.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M6 13.8L9.6 17.0667L18 6.93335"/>
+</svg>

--- a/src/raw/lined/chevron-down-2.svg
+++ b/src/raw/lined/chevron-down-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M16.5096 9.87277L12.0515 14.1823L7.5934 9.87277"/>
+</svg>

--- a/src/raw/lined/chevron-left-2.svg
+++ b/src/raw/lined/chevron-left-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M14.2892 16.5096L9.9797 12.0515L14.2892 7.59337"/>
+</svg>

--- a/src/raw/lined/chevron-right-2.svg
+++ b/src/raw/lined/chevron-right-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M9.87277 7.49036L14.1823 11.9485L9.87277 16.4066"/>
+</svg>

--- a/src/raw/lined/chevron-up-2.svg
+++ b/src/raw/lined/chevron-up-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M7.49039 14.1272L11.9485 9.81771L16.4066 14.1272"/>
+</svg>

--- a/src/raw/lined/corner-down-left-2.svg
+++ b/src/raw/lined/corner-down-left-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M19 5V10.5261C19 11.5575 18.5903 12.5467 17.861 13.276C17.1317 14.0053 16.1425 14.415 15.1111 14.415H5M5 14.415L9.58889 19M5 14.415L9.58889 9.83"/>
+</svg>

--- a/src/raw/lined/corner-left-down-2.svg
+++ b/src/raw/lined/corner-left-down-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M19 5L13.4739 5C12.4425 5 11.4533 5.40972 10.724 6.13903C9.99472 6.86834 9.585 7.85749 9.585 8.88889L9.585 19M9.585 19L5 14.4111M9.585 19L14.17 14.4111"/>
+</svg>

--- a/src/raw/lined/corner-left-up-2.svg
+++ b/src/raw/lined/corner-left-up-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M19 19L13.4739 19C12.4425 19 11.4533 18.5903 10.724 17.861C9.99472 17.1317 9.585 16.1425 9.585 15.1111L9.585 5M9.585 5L5 9.58889M9.585 5L14.17 9.58889"/>
+</svg>

--- a/src/raw/lined/corner-right-down-2.svg
+++ b/src/raw/lined/corner-right-down-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M5 5L10.5261 5C11.5575 5 12.5467 5.40972 13.276 6.13903C14.0053 6.86834 14.415 7.85749 14.415 8.88889L14.415 19M14.415 19L19 14.4111M14.415 19L9.83 14.4111"/>
+</svg>

--- a/src/raw/lined/corner-right-up-2.svg
+++ b/src/raw/lined/corner-right-up-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M5 19L10.5261 19C11.5575 19 12.5467 18.5903 13.276 17.861C14.0053 17.1317 14.415 16.1425 14.415 15.1111L14.415 5M14.415 5L19 9.58889M14.415 5L9.83 9.58889"/>
+</svg>

--- a/src/raw/lined/corner-up-right-2.svg
+++ b/src/raw/lined/corner-up-right-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M5 5L5 10.5261C5 11.5575 5.40972 12.5467 6.13903 13.276C6.86834 14.0053 7.85749 14.415 8.88889 14.415L19 14.415M19 14.415L14.4111 19M19 14.415L14.4111 9.83"/>
+</svg>

--- a/src/raw/lined/minus-2.svg
+++ b/src/raw/lined/minus-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M18 12H6"/>
+</svg>

--- a/src/raw/lined/minus-3.svg
+++ b/src/raw/lined/minus-3.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M17 12H7"/>
+</svg>

--- a/src/raw/lined/plus-2.svg
+++ b/src/raw/lined/plus-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M12 6V18M18 12H6"/>
+</svg>

--- a/src/raw/lined/plus-3.svg
+++ b/src/raw/lined/plus-3.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M12 7V17M17 12H7"/>
+</svg>

--- a/src/raw/lined/x-2.svg
+++ b/src/raw/lined/x-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M7.75735 7.75736L16.2426 16.2426M16.2426 7.75736L7.75735 16.2426"/>
+</svg>

--- a/src/raw/lined/x-3.svg
+++ b/src/raw/lined/x-3.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M8.46446 8.46447L15.5355 15.5355M15.5355 8.46447L8.46446 15.5355"/>
+</svg>


### PR DESCRIPTION
Chromicons are based on a 24x24 viewbox. Some of the icons' content bleeds out to the very edges of the 24x24 viewbox. At times, this is not a desirable look. In order to preserve the 24x24 viewbox and create the look we want, I'm creating some alternative smaller sizes for some of these icons that look a little large in certain use cases.

Button w/ Plus (original) | Button w/ Plus-2
-- | --
 <img width="227" alt="Screenshot 2024-02-21 at 1 29 37 PM" src="https://github.com/lifeomic/chromicons/assets/485903/f876ba88-5dd8-4a32-ba03-65d7a63c7526"> | <img width="227" alt="Screenshot 2024-02-21 at 1 29 47 PM" src="https://github.com/lifeomic/chromicons/assets/485903/46af7ae7-4329-4ef3-ac46-ecc054ab68fe">